### PR TITLE
fix view destruction on favorite on homepage

### DIFF
--- a/src/pages/schedule/schedule.ts
+++ b/src/pages/schedule/schedule.ts
@@ -199,7 +199,6 @@ export class SchedulePage implements OnDestroy {
     if (this.isAuthenticated) {
       if (!session.favorite) {
         this.conferenceData.setFavorite(session.$key);
-        this.viewCtrl.dismiss();
       } else {
         this.conferenceData.removeFavorite(session.favorite.$key);
         delete session.favorite;


### PR DESCRIPTION
Probably a copy-paste mistake :).

On a side-note. Should we destroy the view when favoriting in the details view? I might be pressing "favorite" but that does not mean I want to exit that view.