### PR TITLE
fix non-tech session ratings

### DIFF
--- a/src/pages/rate-session/rate-session.ts
+++ b/src/pages/rate-session/rate-session.ts
@@ -81,6 +81,8 @@ export class RateSessionPage {
   private populateRating() {
 
     if (this.session.rating) {
+      this.session.rating.speakers = this.session.rating.speakers || [];
+
       delete this.session.rating.$exists;
       this.sessionRating = this.session.rating;
       this.session.rating.speakers.forEach((speakerA) => {


### PR DESCRIPTION
So this change fixes a bug when you want to change a rating from a non-tech session. For instance, rate the continental breakfast and save it. Then try to change that rating. The modal window will not show up because the rating don't have speakers and it is saved as `undefined` in Firebase.

Initially I wanted to add this empty list somewhere in the data service upon retrieval, but couldn't really find the correct place to do it.