### PR TITLE
remove duplicate twitter provider if clause

### DIFF
--- a/src/services/auth.service.ts
+++ b/src/services/auth.service.ts
@@ -90,10 +90,6 @@ export class AuthService {
       if (state.provider == AuthProviders.Twitter && state.twitter.displayName) {
         this.rpCurrentUser$.next(state.twitter);
         this.isAuthenticated$.next(true);
-      }
-      if (state.provider == AuthProviders.Twitter && state.twitter.displayName) {
-        this.rpCurrentUser$.next(state.twitter);
-        this.isAuthenticated$.next(true);
         this.storage.set('previousLoginMethod', 'Twitter');
       }
       if (state.provider == AuthProviders.Github && state.github.displayName) {


### PR DESCRIPTION
The Twitter provider is checked twice and the `previousLoginMethod` is not stored in localstorage this way. So I removed the first check and made sure it's stored. Not sure if storing that information is necessary though.